### PR TITLE
security: authenticate emergency API + verify HA webhook + rate-limit

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,44 @@
+# SafeR CI — Backend environment variables
+# Copy to .env and fill in real values. Never commit the real .env.
+
+# ── App ────────────────────────────────────────────────────────────────
+# Secret used to sign JWTs / session tokens. Generate: openssl rand -hex 32
+SECRET_KEY=change-me-generate-with-openssl-rand-hex-32
+DEBUG=false
+
+# Shared bearer token for the emergency API. Callers send it as
+#   Authorization: Bearer <token>
+# Protects incident create/read/update/PII endpoints (there is no user
+# login system yet). Generate: openssl rand -hex 32
+# NOTE: if left empty the protected endpoints fail closed with HTTP 503.
+SAFER_API_TOKEN=change-me-generate-with-openssl-rand-hex-32
+
+# HMAC-SHA256 shared secret for the Home Assistant webhook (POST /webhook/ha).
+# HA must send header  X-Hub-Signature-256: sha256=<hexdigest of raw body>.
+# Generate: openssl rand -hex 32
+# NOTE: if left empty the webhook fails closed with HTTP 503.
+HUB_WEBHOOK_SECRET=change-me-generate-with-openssl-rand-hex-32
+
+# ── Database ───────────────────────────────────────────────────────────
+# Must match POSTGRES_PASSWORD below when using docker-compose.
+DATABASE_URL=postgresql+asyncpg://safer:change-me-strong-db-password@db:5432/safer_ci
+# Used by docker-compose to provision Postgres and build DATABASE_URL.
+POSTGRES_PASSWORD=change-me-strong-db-password
+
+# ── Redis ──────────────────────────────────────────────────────────────
+# Password is required (Redis runs with --requirepass in docker-compose).
+REDIS_URL=redis://:change-me-strong-redis-password@redis:6379/0
+REDIS_PASSWORD=change-me-strong-redis-password
+
+# ── Twilio (SMS) ───────────────────────────────────────────────────────
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
+
+# ── Firebase (push notifications) ──────────────────────────────────────
+FIREBASE_PROJECT_ID=
+FIREBASE_CREDENTIALS_JSON=
+
+# ── WhatsApp Business API ──────────────────────────────────────────────
+WHATSAPP_TOKEN=
+WHATSAPP_PHONE_NUMBER_ID=

--- a/backend/app/api/routes/incidents.py
+++ b/backend/app/api/routes/incidents.py
@@ -3,10 +3,15 @@ SafeR CI — Incidents API Routes
 Handles incident creation from HA nodes, mobile app, and SMS gateway
 """
 from typing import List, Optional
-from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Query
+from fastapi import (
+    APIRouter, Depends, HTTPException, BackgroundTasks, Query, Request,
+)
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
+from app.core.rate_limit import limiter
+from app.core.security import require_api_token, verify_ha_signature
 from app.schemas.incident import IncidentCreate, IncidentResponse, IncidentUpdate
 from app.services.incident_service import IncidentService
 from app.services.notification_service import NotificationService
@@ -14,8 +19,30 @@ from app.services.notification_service import NotificationService
 router = APIRouter()
 
 
-@router.post("/", response_model=IncidentResponse, status_code=201)
+class HAWebhookPayload(BaseModel):
+    """Validated payload for the Home Assistant webhook.
+
+    Enforces sane GPS bounds and numeric coercion, which also removes the
+    unvalidated ``float()`` denial-of-service on the raw dict.
+    """
+
+    incident_type: str = "other"
+    severity: str = "medium"
+    location_lat: float = Field(5.3600, ge=-90.0, le=90.0)
+    location_lon: float = Field(-4.0083, ge=-180.0, le=180.0)
+    hub_id: Optional[str] = None
+    triggered_by: Optional[str] = None
+
+
+@router.post(
+    "/",
+    response_model=IncidentResponse,
+    status_code=201,
+    dependencies=[Depends(require_api_token)],
+)
+@limiter.limit("10/minute")
 async def create_incident(
+    request: Request,
     incident_data: IncidentCreate,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
@@ -37,7 +64,11 @@ async def create_incident(
     return incident
 
 
-@router.get("/", response_model=List[IncidentResponse])
+@router.get(
+    "/",
+    response_model=List[IncidentResponse],
+    dependencies=[Depends(require_api_token)],
+)
 async def get_incidents(
     lat: Optional[float] = Query(None, description="Center latitude"),
     lon: Optional[float] = Query(None, description="Center longitude"),
@@ -69,7 +100,11 @@ async def get_incidents(
     return incidents
 
 
-@router.get("/{incident_id}", response_model=IncidentResponse)
+@router.get(
+    "/{incident_id}",
+    response_model=IncidentResponse,
+    dependencies=[Depends(require_api_token)],
+)
 async def get_incident(incident_id: str, db: AsyncSession = Depends(get_db)):
     """Get a single incident by ID."""
     service = IncidentService(db)
@@ -79,7 +114,11 @@ async def get_incident(incident_id: str, db: AsyncSession = Depends(get_db)):
     return incident
 
 
-@router.patch("/{incident_id}", response_model=IncidentResponse)
+@router.patch(
+    "/{incident_id}",
+    response_model=IncidentResponse,
+    dependencies=[Depends(require_api_token)],
+)
 async def update_incident(
     incident_id: str,
     update_data: IncidentUpdate,
@@ -93,24 +132,29 @@ async def update_incident(
     return incident
 
 
-@router.post("/webhook/ha")
+@router.post("/webhook/ha", dependencies=[Depends(verify_ha_signature)])
+@limiter.limit("10/minute")
 async def ha_webhook(
-    payload: dict,
+    request: Request,
+    payload: HAWebhookPayload,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
     """
     Webhook endpoint called by Home Assistant automations.
     Translates HA event data to SafeR incident format.
+
+    The raw body must carry a valid ``X-Hub-Signature-256`` HMAC (verified by
+    ``verify_ha_signature``); the payload is schema-validated (GPS bounds).
     """
     service = IncidentService(db)
     incident_data = IncidentCreate(
-        incident_type=payload.get("incident_type", "other"),
-        severity=payload.get("severity", "medium"),
-        location_lat=float(payload.get("location_lat", 5.3600)),
-        location_lon=float(payload.get("location_lon", -4.0083)),
-        hub_id=payload.get("hub_id"),
-        triggered_by=payload.get("triggered_by"),
+        incident_type=payload.incident_type,
+        severity=payload.severity,
+        location_lat=payload.location_lat,
+        location_lon=payload.location_lon,
+        hub_id=payload.hub_id,
+        triggered_by=payload.triggered_by,
         source="ha_node",
     )
     incident = await service.create_incident(incident_data)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,10 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
 
+    # API auth — shared bearer token for the emergency API (no user system yet).
+    # Callers (mobile app, SMS gateway, dashboard) send: Authorization: Bearer <token>
+    SAFER_API_TOKEN: str = ""
+
     # Database
     DATABASE_URL: str
     DATABASE_POOL_SIZE: int = 10

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,11 @@
+"""
+SafeR CI — Rate limiting
+
+Shared slowapi limiter, keyed by client IP. Imported by ``main.py`` (to wire the
+limiter and its exception handler into the app) and by the route modules (to
+decorate individual endpoints such as incident-create and the HA webhook).
+"""
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,75 @@
+"""
+SafeR CI — API security helpers
+
+Pragmatic, immediate protection for the emergency API. There is no user/login
+system yet, so we use a shared bearer token for the mutating/PII endpoints and
+an HMAC-SHA256 signature for the Home Assistant webhook. Both comparisons are
+constant-time. These guards fail closed when their secret is unconfigured.
+"""
+import hmac
+from hashlib import sha256
+
+from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.core.config import settings
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def require_api_token(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+) -> None:
+    """
+    Verify the caller's bearer token against ``settings.SAFER_API_TOKEN``.
+
+    Fails closed with 503 when no token is configured, and 401 on a missing or
+    mismatched token. Uses a constant-time comparison to avoid timing attacks.
+    """
+    expected = settings.SAFER_API_TOKEN
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="API authentication is not configured",
+        )
+    if credentials is None or not hmac.compare_digest(
+        credentials.credentials, expected
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+async def verify_ha_signature(
+    request: Request,
+    x_hub_signature_256: str = Header(default=None, alias="X-Hub-Signature-256"),
+) -> None:
+    """
+    Verify the HMAC-SHA256 signature of the raw request body against
+    ``settings.HUB_WEBHOOK_SECRET``.
+
+    The signature header value must be ``sha256=<hexdigest>``. Fails closed with
+    503 when no secret is configured, 401 when the signature header is missing,
+    and 403 on mismatch. FastAPI caches the body, so parsing the Pydantic model
+    afterwards still works.
+    """
+    secret = settings.HUB_WEBHOOK_SECRET
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook secret is not configured",
+        )
+    if not x_hub_signature_256:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing webhook signature",
+        )
+    body = await request.body()
+    expected = "sha256=" + hmac.new(secret.encode(), body, sha256).hexdigest()
+    if not hmac.compare_digest(x_hub_signature_256, expected):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid webhook signature",
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,8 +43,10 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    # With allow_credentials=True, wildcards echo the caller's origin/headers and
+    # defeat the allowlist — restrict to exactly what the browser dashboard uses.
+    allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Routers

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,10 +6,14 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from app.api.routes import incidents, alerts, users, health
 from app.core.config import settings
 from app.core.database import init_db
+from app.core.rate_limit import limiter
 
 
 @asynccontextmanager
@@ -27,6 +31,11 @@ app = FastAPI(
     redoc_url="/redoc" if settings.DEBUG else None,
     lifespan=lifespan,
 )
+
+# Rate limiting (slowapi) — shared limiter keyed by client IP.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # Middleware
 app.add_middleware(GZipMiddleware, minimum_size=1000)

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql+asyncpg://safer:safer_pass@db:5432/safer_ci
-      - REDIS_URL=redis://redis:6379/0
+      - DATABASE_URL=postgresql+asyncpg://safer:${POSTGRES_PASSWORD}@db:5432/safer_ci
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
     env_file:
       - .env
     depends_on:
@@ -28,10 +28,9 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: safer
-      POSTGRES_PASSWORD: safer_pass
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
       POSTGRES_DB: safer_ci
-    ports:
-      - "5432:5432"
+    # No host port publishing: db is only reachable on the internal compose network.
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -44,8 +43,8 @@ services:
     image: redis:7-alpine
     container_name: safer_redis
     restart: unless-stopped
-    ports:
-      - "6379:6379"
+    # No host port publishing; require a password for any in-network client.
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env}"]
     volumes:
       - redis_data:/data
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,8 +11,10 @@ celery==5.3.6
 httpx==0.27.0
 twilio==8.14.0
 firebase-admin==6.4.0
-python-jose[cryptography]==3.3.0
+# Bumped from 3.3.0 (CVE-2024-33663 algorithm confusion / CVE-2024-33664 JWE DoS)
+python-jose[cryptography]==3.4.0
 passlib[bcrypt]==1.7.4
+slowapi==0.1.9
 python-multipart==0.0.9
 psycopg2-binary==2.9.9
 greenlet==3.0.3

--- a/ha-config/automations/mobile_app_control.yaml
+++ b/ha-config/automations/mobile_app_control.yaml
@@ -14,7 +14,7 @@
     - platform: webhook
       webhook_id: !secret safer_webhook_sos
       allowed_methods: [POST]
-      local_only: false
+      local_only: true
     # Via MQTT (app mobile publie directement)
     - platform: mqtt
       topic: safer/mobile/sos

--- a/ha-config/rest_commands.yaml
+++ b/ha-config/rest_commands.yaml
@@ -13,7 +13,7 @@ safer_post_incident:
   headers:
     Content-Type: application/json
     X-SafeR-Source: "home_assistant"
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "type": "{{ type }}",
@@ -34,7 +34,7 @@ safer_update_incident:
   headers:
     Content-Type: application/json
     X-SafeR-Source: "home_assistant"
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "status": "{{ status }}",
@@ -50,7 +50,7 @@ safer_resolve_incident:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "status": "{{ status | default('resolved') }}",
@@ -69,7 +69,7 @@ safer_dispatch_responder:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "type": "{{ type }}",
@@ -90,7 +90,7 @@ safer_push_notification:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "title": "{{ title }}",
@@ -106,11 +106,15 @@ safer_push_notification:
 
 # Envoyer alerte WhatsApp via Twilio API
 safer_whatsapp_alert:
-  url: "https://api.twilio.com/2010-04-01/Accounts/!secret twilio_account_sid/Messages.json"
+  # `!secret` only resolves as an unquoted YAML tag on a whole value, so the full
+  # Twilio Messages URL (which embeds the Account SID) is stored in secrets.yaml.
+  url: !secret twilio_messages_url
   method: POST
-  username: "!secret twilio_account_sid"
-  password: "!secret twilio_auth_token"
-  payload: "From=whatsapp:!secret twilio_from_number&To=whatsapp:{{ to }}&Body={{ message | urlencode }}"
+  username: !secret twilio_account_sid
+  password: !secret twilio_auth_token
+  # The WhatsApp sender is a template value (payload also templates `to`/`message`),
+  # and secrets cannot be read inside templates — source it from an input_text helper.
+  payload: "From={{ states('input_text.safer_twilio_from') }}&To=whatsapp:{{ to }}&Body={{ message | urlencode }}"
   content_type: "application/x-www-form-urlencoded"
 
 # Diffusion à toutes les zones
@@ -119,7 +123,7 @@ safer_broadcast_all:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "message": "{{ message }}",
@@ -140,7 +144,7 @@ safer_sensor_update:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "entity_id": "{{ entity_id }}",
@@ -156,7 +160,7 @@ safer_generate_report:
   method: POST
   headers:
     Content-Type: application/json
-    Authorization: "Bearer !secret safer_api_key"
+    Authorization: !secret safer_api_authorization
   payload: >-
     {
       "date": "{{ date }}",
@@ -175,7 +179,7 @@ safer_notify_dashboard:
   method: POST
   headers:
     Content-Type: application/json
-    X-HA-Webhook-Secret: "!secret ha_webhook_secret"
+    X-HA-Webhook-Secret: !secret ha_webhook_secret
   payload: >-
     {
       "event": "{{ event_type }}",
@@ -194,6 +198,8 @@ safer_create_incident_vercel:
   method: POST
   headers:
     Content-Type: application/json
+    # Server-to-server auth for POST /api/incidents (matches INCIDENTS_API_TOKEN on Vercel).
+    Authorization: !secret safer_dashboard_incidents_authorization
   payload: >-
     {
       "type": "{{ type }}",

--- a/ha-config/secrets.yaml.example
+++ b/ha-config/secrets.yaml.example
@@ -6,9 +6,13 @@
 # ============================================================
 # TWILIO SMS / WHATSAPP
 # ============================================================
-twilio_account_sid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-twilio_auth_token: "your_auth_token_here"
-twilio_from_number: "+1XXXXXXXXXX"  # Votre numéro Twilio
+twilio_account_sid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # Utilisé comme username Basic Auth
+twilio_auth_token: "your_auth_token_here"                # Utilisé comme password Basic Auth
+# URL complète de l'API Messages Twilio (le SID est intégré dans l'URL).
+# `!secret` ne se résout que sur une valeur entière non quotée, d'où l'URL complète ici.
+twilio_messages_url: "https://api.twilio.com/2010-04-01/Accounts/ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/Messages.json"
+# Le numéro expéditeur WhatsApp est fourni via l'aide input_text.safer_twilio_from
+# (valeur ex: "whatsapp:+1XXXXXXXXXX") car les secrets ne sont pas lisibles dans les templates.
 
 # Contacts d'urgence (numéros en format international +225...)
 emergency_contact_1: "+225XXXXXXXXXX"  # Administrateur principal
@@ -27,7 +31,10 @@ whatsapp_group_id: "whatsapp:+225XXXXXXXXXX"  # Groupe WhatsApp d'urgence
 # ============================================================
 # API BACKEND SAFER
 # ============================================================
-safer_api_key: "your_safer_api_key_here"  # Clé API FastAPI/Next.js
+safer_api_key: "your_safer_api_key_here"  # Clé API FastAPI/Next.js (brute)
+# En-tête Authorization COMPLET (schéma "Bearer " inclus). Référencé sans guillemets
+# via `Authorization: !secret safer_api_authorization` dans rest_commands.yaml.
+safer_api_authorization: "Bearer your_safer_api_key_here"
 safer_api_base_url: "http://localhost:8000"  # URL du backend en production
 
 # ============================================================
@@ -38,6 +45,9 @@ safer_webhook_sos: "your_random_webhook_id_for_sos"
 safer_webhook_dispatch: "your_random_webhook_id_for_dispatch"
 safer_webhook_resolve: "your_random_webhook_id_for_resolve"
 ha_webhook_secret: "your_ha_webhook_secret_here"
+# En-tête Authorization COMPLET pour POST /api/incidents du dashboard Vercel.
+# Doit correspondre à INCIDENTS_API_TOKEN côté Vercel. Générez: openssl rand -hex 32
+safer_dashboard_incidents_authorization: "Bearer your_incidents_api_token_here"
 
 # ============================================================
 # MQTT BROKER

--- a/web-dashboard/.env.example
+++ b/web-dashboard/.env.example
@@ -14,6 +14,16 @@ NEXT_PUBLIC_APP_ENV=development
 # If empty, the webhook route fails closed with HTTP 503.
 HA_WEBHOOK_SECRET=change-me-generate-with-openssl-rand-hex-32
 
+# Server-only shared secret required for POST /api/incidents (machine callers such
+# as Home Assistant send it as  Authorization: Bearer <token>).
+# NOT NEXT_PUBLIC — must never reach the browser. Generate: openssl rand -hex 32
+# If unset AND NEXT_PUBLIC_DEMO_MODE != "true", the POST route rejects with HTTP 401.
+INCIDENTS_API_TOKEN=change-me-generate-with-openssl-rand-hex-32
+
+# Demo mode: when "true", the public in-app SOS button may POST /api/incidents
+# WITHOUT a token (demo deployments only). Leave unset/false in production.
+NEXT_PUBLIC_DEMO_MODE=true
+
 # Map defaults (Abidjan center)
 NEXT_PUBLIC_MAP_DEFAULT_LAT=5.3484
 NEXT_PUBLIC_MAP_DEFAULT_LON=-4.0107

--- a/web-dashboard/.env.example
+++ b/web-dashboard/.env.example
@@ -8,6 +8,12 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_APP_NAME=SafeR CI
 NEXT_PUBLIC_APP_ENV=development
 
+# Server-only shared secret for the HA webhook route (POST /api/incidents/webhook/ha).
+# Home Assistant must send it in the  X-HA-Webhook-Secret  header.
+# NOT NEXT_PUBLIC — must never be exposed to the browser. Generate: openssl rand -hex 32
+# If empty, the webhook route fails closed with HTTP 503.
+HA_WEBHOOK_SECRET=change-me-generate-with-openssl-rand-hex-32
+
 # Map defaults (Abidjan center)
 NEXT_PUBLIC_MAP_DEFAULT_LAT=5.3484
 NEXT_PUBLIC_MAP_DEFAULT_LON=-4.0107

--- a/web-dashboard/package.json
+++ b/web-dashboard/package.json
@@ -15,7 +15,8 @@
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
     "lucide-react": "^0.378.0",
-    "clsx": "^2.1.1"
+    "clsx": "^2.1.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.12",

--- a/web-dashboard/src/app/api/incidents/route.ts
+++ b/web-dashboard/src/app/api/incidents/route.ts
@@ -1,15 +1,56 @@
+import { timingSafeEqual } from 'crypto';
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import { MOCK_INCIDENTS } from '@/lib/mock-data';
 import type { Incident } from '@/types/incident';
 
 // In-memory store for demo incidents (resets on cold start)
 let incidents: Incident[] = [...MOCK_INCIDENTS];
 
+// Constant-time comparison that does not leak length via early return.
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+// When true (demo deployments) the public SOS button may POST without a token.
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
+
+// Server-only shared secret for machine callers (e.g. Home Assistant).
+// Sent as  Authorization: Bearer <token>. Never NEXT_PUBLIC_.
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.INCIDENTS_API_TOKEN;
+  if (!expected) return false;
+  const header = request.headers.get('authorization') ?? '';
+  const provided = header.startsWith('Bearer ') ? header.slice(7) : '';
+  return provided.length > 0 && safeEqual(provided, expected);
+}
+
+// Bounded, typed validation of the incident payload to prevent feed poisoning.
+// Unknown keys are stripped; every field is optional (defaults applied below).
+const IncidentInput = z.object({
+  incident_type: z
+    .enum(['panic', 'fire', 'flood', 'accident', 'crime', 'medical', 'other'])
+    .optional(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+  location_lat: z.number().min(-90).max(90).optional(),
+  location_lon: z.number().min(-180).max(180).optional(),
+  location_name: z.string().max(200).optional(),
+  commune: z.string().max(120).optional(),
+  description: z.string().max(1000).optional(),
+  source: z.string().max(60).optional(),
+});
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const status = searchParams.get('status');
   const type = searchParams.get('incident_type');
-  
+
   let filtered = incidents;
   if (status && status !== 'all') {
     filtered = filtered.filter(i => i.status === status);
@@ -17,30 +58,49 @@ export async function GET(request: Request) {
   if (type) {
     filtered = filtered.filter(i => i.incident_type === type);
   }
-  
+
   return NextResponse.json(filtered.sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   ));
 }
 
 export async function POST(request: Request) {
-  const body = await request.json();
-  
+  // Require a valid token; in demo mode the public SOS button is allowed through.
+  if (!isAuthorized(request) && !DEMO_MODE) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = IncidentInput.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid incident payload', details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const body = parsed.data;
+
   const newIncident: Incident = {
     id: Date.now().toString(),
     incident_type: body.incident_type || 'panic',
     severity: body.severity || 'critical',
     status: 'open',
-    location_lat: body.location_lat || 5.3600,
-    location_lon: body.location_lon || -4.0083,
+    location_lat: body.location_lat ?? 5.3600,
+    location_lon: body.location_lon ?? -4.0083,
     location_name: body.location_name || 'Position inconnue',
     commune: body.commune,
     description: body.description || 'Alerte SOS depuis l\'application web',
     created_at: new Date().toISOString(),
     source: body.source || 'web_dashboard',
   };
-  
+
   incidents = [newIncident, ...incidents];
-  
+
   return NextResponse.json(newIncident, { status: 201 });
 }

--- a/web-dashboard/src/app/api/incidents/webhook/ha/route.ts
+++ b/web-dashboard/src/app/api/incidents/webhook/ha/route.ts
@@ -1,14 +1,39 @@
+import { timingSafeEqual } from 'crypto';
 import { NextResponse } from 'next/server';
+
+// Constant-time string comparison that does not leak length via early return.
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Compare against self to keep timing uniform, then fail.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 // This endpoint receives webhooks from Home Assistant nodes
 export async function POST(request: Request) {
-  const payload = await request.json();
-  console.log('[SafeR CI] HA Webhook received:', payload);
-  
+  const expected = process.env.HA_WEBHOOK_SECRET;
+  if (!expected) {
+    // Fail closed when the secret is not configured on the server.
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+  }
+
+  const provided = request.headers.get('x-ha-webhook-secret') ?? '';
+  if (!safeEqual(provided, expected)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Consume the body but do not log it (contains victim GPS/PII).
+  await request.json();
+  console.log('[SafeR CI] HA Webhook received (authenticated)');
+
   // In production: forward to database + trigger notifications
   // For demo: just acknowledge
-  return NextResponse.json({ 
-    status: 'ok', 
+  return NextResponse.json({
+    status: 'ok',
     message: 'Incident received from HA node',
     incident_id: Date.now().toString(),
     received_at: new Date().toISOString(),


### PR DESCRIPTION
## Critical security fixes — emergency API

Automated audit (Fable 5) + fixes. See `SECURITY-AUDIT-2026-07-02.md`.

- **CRITICAL** unauthenticated `POST/GET/PATCH /incidents` (fake SOS dispatch + harvest of victim GPS/PII) → now require a bearer token (`SAFER_API_TOKEN`, constant-time compare).
- **CRITICAL** unsigned HA webhook → verifies `X-Hub-Signature-256` HMAC vs `HUB_WEBHOOK_SECRET`; payload now a validated Pydantic model (also fixes coord `float()` DoS).
- **HIGH** rate-limited (slowapi, 10/min) on create + webhook; SOS automation set `local_only: true`.
- **MED** `python-jose` 3.3.0→3.4.0 (CVE-2024-33663/33664); compose creds/ports hardened; dashboard webhook verifies its secret + stops logging PII.

**Verified:** py_compile ✓, pylint 9.11/10.
**Note:** shared-token stopgap — full per-user RBAC (object-level ownership) is a follow-up; HA must be configured to send the signature headers; use Redis-backed rate limiting for multi-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
